### PR TITLE
Correctly reference the typings in package.json to enable imports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "typescript"
   ],
   "main": "dist/index.js",
+  "browser": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "typings": "typings i",
     "prebuild": "npm run typings && npm run lint",


### PR DESCRIPTION
The package.json file in meteor-rxjs doesn't reference the dist files correctly.

I copied the matching settings from angular2-meteor.