### PR TITLE
Add complete() support to zone operator

### DIFF
--- a/dist/zone.js
+++ b/dist/zone.js
@@ -30,6 +30,12 @@ var ZoneSubscriber = (function (_super) {
             _this.destination.next(value);
         });
     };
+    ZoneSubscriber.prototype._complete = function () {
+        var _this = this;
+        this.zone.run(function () {
+            _this.destination.complete();
+        });
+    };
     ZoneSubscriber.prototype._error = function (err) {
         var _this = this;
         this.zone.run(function () {

--- a/src/zone.ts
+++ b/src/zone.ts
@@ -28,6 +28,12 @@ class ZoneSubscriber<T> extends Subscriber<T> {
     });
   }
 
+  protected _complete() {
+    this.zone.run(() => {
+      this.destination.complete();
+    });
+  }
+
   protected _error(err?: any) {
     this.zone.run(() => {
       this.destination.error(err);


### PR DESCRIPTION
Calling complete() on an observer can now also be run in the zone.