### PR TITLE
Replace 'meteor-typings' with '@types/meteor'

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -35,7 +35,6 @@
         "conventional-changelog-cli",
         "zone.js",
         "reflect-metadata",
-        "meteor-typings",
         "@types/*"
       ]
     }

--- a/dist/MeteorObservable.d.ts
+++ b/dist/MeteorObservable.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="meteor-typings" />
+/// <reference types="@types/meteor" />
 import { Observable } from 'rxjs';
 /**
  * This is a class with static methods that wrap Meteor's API and return RxJS

--- a/dist/ObservableCollection.d.ts
+++ b/dist/ObservableCollection.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="chai" />
-/// <reference types="meteor-typings" />
+/// <reference types="@types/meteor" />
 import { Observable } from 'rxjs';
 import { ObservableCursor } from './ObservableCursor';
 import Selector = Mongo.Selector;

--- a/dist/ObservableCursor.d.ts
+++ b/dist/ObservableCursor.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="meteor-typings" />
+/// <reference types="@types/meteor" />
 import { Observable } from 'rxjs';
 export declare class ObservableCursor<T> extends Observable<T[]> {
     private _zone;

--- a/examples/angular2/package.json
+++ b/examples/angular2/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser": "2.1.2",
     "@angular/platform-browser-dynamic": "2.1.2",
     "@angular/router": "3.1.2",
+    "@types/meteor": "1.3.31",
     "angular2-meteor": "0.7.0",
     "angular2-meteor-polyfills": "0.1.1",
     "angular2-meteor-tests-polyfills": "0.0.2",
@@ -31,7 +32,6 @@
     "meteor-rxjs": "../../",
     "reflect-metadata": "0.1.8",
     "rxjs": "5.0.0-beta.12",
-    "zone.js": "0.6.26",
-    "meteor-typings": "1.3.1"
+    "zone.js": "0.6.26"
   }
 }

--- a/examples/angular2/typings.d.ts
+++ b/examples/angular2/typings.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="zone.js" />
-/// <reference types="meteor-typings" />
+/// <reference types="@types/meteor" />
 /// <reference types="@types/underscore" />
 
 declare module "*.html" {

--- a/package.json
+++ b/package.json
@@ -41,15 +41,15 @@
     "rxjs": "^5.0.0-beta.12"
   },
   "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/meteor": "^1.3.31",
     "@types/mocha": "2.2.33",
     "@types/underscore": "1.7.36",
-    "@types/chai": "^3.4.34",
     "conventional-changelog": "1.1.0",
     "conventional-changelog-cli": "1.2.0",
     "es6-shim": "0.35.2",
     "ghooks": "1.3.2",
     "jsdoc-to-markdown": "2.0.1",
-    "meteor-typings": "1.3.1",
     "rollup": "0.37.0",
     "rxjs": "^5.0.0-rc.4",
     "tslint": "4.1.0",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,4 +1,4 @@
 /// <reference types="zone.js" />
-/// <reference types="meteor-typings" />
-/// <reference types="@types/underscore" />
 /// <reference types="@types/chai" />
+/// <reference types="@types/meteor" />
+/// <reference types="@types/underscore" />


### PR DESCRIPTION
This is an important replacement, because you would expect the '@types' repository to be the so-called mother-base for all type declarations. It was originally made as a part of an integration with recent "Ionic2CLI-Meteor-Whatsapp" update. All tests are passing :-)