### PR TITLE
Stop relying on underscore.js' _ being magically available

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "http://www.angular-meteor.com",
   "peerDependencies": {
+    "lodash": "^4.17.15",
     "@types/meteor": "^1.4.6",
     "rxjs": "^5.4.3 || ^6.0.0"
   },
@@ -44,7 +45,7 @@
     "@types/chai": "4.0.4",
     "@types/meteor": "1.4.14",
     "@types/mocha": "2.2.43",
-    "@types/underscore": "1.8.3",
+    "@types/lodash": "4.14.142",
     "conventional-changelog": "1.1.0",
     "conventional-changelog-cli": "1.2.0",
     "jsdoc-to-markdown": "3.0.0",

--- a/src/ObservableCursor.ts
+++ b/src/ObservableCursor.ts
@@ -2,7 +2,7 @@ import { Observable ,  Subscriber ,  Subject } from 'rxjs';
 
 import { gZone, forkZone, removeObserver } from './utils';
 
-declare let _;
+import * as _ from 'lodash';
 
 export class ObservableCursor<T> extends Observable<T[]> {
   private _zone: Zone;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { Subscriber } from 'rxjs';
 
-declare let _;
+import * as _ from 'lodash';
 
 export declare type CallbacksObject = {
   onReady?: Function;


### PR DESCRIPTION
Fixes #246

Use [lodash](https://www.npmjs.com/package/lodash), which is already an indirect dependency.
